### PR TITLE
➕ Aruba for testing cli

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,5 @@ gem "rake"
 gem "rspec"
 
 gem "standard"
+
+gem "aruba", "~> 2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,12 +7,50 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    aruba (2.2.0)
+      bundler (>= 1.17, < 3.0)
+      contracts (>= 0.16.0, < 0.18.0)
+      cucumber (>= 8.0, < 10.0)
+      rspec-expectations (~> 3.4)
+      thor (~> 1.0)
     ast (2.4.2)
+    bigdecimal (3.1.8)
+    builder (3.3.0)
     commonmarker (0.23.10)
+    contracts (0.17)
+    cucumber (9.2.0)
+      builder (~> 3.2)
+      cucumber-ci-environment (> 9, < 11)
+      cucumber-core (> 13, < 14)
+      cucumber-cucumber-expressions (~> 17.0)
+      cucumber-gherkin (> 24, < 28)
+      cucumber-html-formatter (> 20.3, < 22)
+      cucumber-messages (> 19, < 25)
+      diff-lcs (~> 1.5)
+      mini_mime (~> 1.1)
+      multi_test (~> 1.1)
+      sys-uname (~> 1.2)
+    cucumber-ci-environment (10.0.1)
+    cucumber-core (13.0.2)
+      cucumber-gherkin (>= 27, < 28)
+      cucumber-messages (>= 20, < 23)
+      cucumber-tag-expressions (> 5, < 7)
+    cucumber-cucumber-expressions (17.1.0)
+      bigdecimal
+    cucumber-gherkin (27.0.0)
+      cucumber-messages (>= 19.1.4, < 23)
+    cucumber-html-formatter (21.4.0)
+      cucumber-messages (> 19, < 25)
+    cucumber-messages (22.0.0)
+    cucumber-tag-expressions (6.1.0)
     diff-lcs (1.5.1)
+    ffi (1.17.0)
+    ffi (1.17.0-x86_64-darwin)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
+    mini_mime (1.1.5)
+    multi_test (1.1.0)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -64,6 +102,9 @@ GEM
     standard-performance (1.3.1)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.20.2)
+    sys-uname (1.3.0)
+      ffi (~> 1.1)
+    thor (1.3.1)
     unicode-display_width (2.5.0)
 
 PLATFORMS
@@ -71,6 +112,7 @@ PLATFORMS
   x86_64-darwin-22
 
 DEPENDENCIES
+  aruba (~> 2.2)
   grokdown!
   rake
   rspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "aruba/rspec"
+
 require "grokdown"
 require "grokdown/matching"
 


### PR DESCRIPTION
Valdated with:

#### `spec/exe/grokdown_spec.rb`

```ruby
require "spec_helper"

RSpec.describe "grokdown", type: :aruba do
  before do
    write_file ".grokdown", ""
    run_command("grokdown")
  end

  it { expect(last_command_started).to have_output ".grokdown" }
end
```

#### `exe/grokdown`
```ruby
#!/usr/bin/env ruby

require "bundler/setup"
require "grokdown"

document_definition = Pathname.glob(".grokdown").find { _1.exist? }

puts document_definition
```