### PR TITLE
♻️ consumes to hook method aggregate_node

### DIFF
--- a/spec/grokdown/consuming_spec.rb
+++ b/spec/grokdown/consuming_spec.rb
@@ -3,28 +3,38 @@ require "commonmarker"
 require "grokdown/consuming"
 
 RSpec.describe Grokdown::Consuming do
-  it "#consume? a node with class mapped by .consumes is true" do
+  it "#consume? returns true if Grokdown::Consuming.aggregate_node passed node-instance of a class mapped by .aggregrate_node is true" do
     described_module = described_class
 
     type = Class.new do
       extend described_module
+
+      def self.aggregate_node(inst, node)
+        case node
+        when CommonMarker::Node
+          inst.gimme(node)
+        end
+      end
     end
 
     _doc, _paragraph, link, _text = *CommonMarker.render_doc("[the node text](https://host.com)").walk
 
-    type.consumes CommonMarker::Node => :gimme
-
     expect(type.new).to be_consumes(link)
   end
 
-  it "#consume? a node with class not mapped by .consumes is false" do
+  it "#consume? a node with class not mapped by .aggregrate_node is false" do
     described_module = described_class
 
     type = Class.new do
       extend described_module
-    end
 
-    type.consumes CommonMarker::Node => :gimme
+      def self.aggregate_node(inst, node)
+        case node
+        when CommonMarker::Node
+          inst.gimme(node)
+        end
+      end
+    end
 
     expect(type.new).not_to be_consumes(Class.new.new)
   end
@@ -35,12 +45,17 @@ RSpec.describe Grokdown::Consuming do
     type = Class.new do
       extend described_module
 
+      def self.aggregate_node(inst, node)
+        case node
+        when CommonMarker::Node
+          inst.gimme(node)
+        end
+      end
+
       def gimme(node) = node
     end
 
     _doc, _paragraph, link, _text = *CommonMarker.render_doc("[the node text](https://host.com)").walk
-
-    type.consumes CommonMarker::Node => :gimme
 
     consumer = type.new
 
@@ -56,9 +71,14 @@ RSpec.describe Grokdown::Consuming do
 
     type = Class.new do
       extend described_module
-    end
 
-    type.consumes CommonMarker::Node => :gimme
+      def self.aggregate_node(inst, node)
+        case node
+        when CommonMarker::Node
+          inst.gimme(node)
+        end
+      end
+    end
 
     consumer = type.new
 
@@ -72,9 +92,14 @@ RSpec.describe Grokdown::Consuming do
 
     type = Class.new do
       extend described_module
-    end
 
-    type.consumes CommonMarker::Node => :gimme
+      def self.aggregate_node(inst, node)
+        case node
+        when CommonMarker::Node
+          inst.gimme(node)
+        end
+      end
+    end
 
     consumer = type.new
 

--- a/spec/grokdown/document_spec.rb
+++ b/spec/grokdown/document_spec.rb
@@ -12,12 +12,11 @@ RSpec.describe Grokdown::Document do
     expect(described_class.new("[text](https://host.com)").walk.to_a).to eq([Grokdown::NeverConsumes.new(doc), Grokdown::NeverConsumes.new(paragraph), Grokdown::NeverConsumes.new(link), Grokdown::NeverConsumes.new(text)])
   end
 
-  it "with some Classes with Grokdown::Matching.matches_node?, builds matching instances with Grokdown::Matching.arguments_from_node, and reshapes the tree a bit with Growkdown::Consuming.consumes", :aggregate_failures do
+  it "with some Classes with Grokdown::Matching.matches_node?, builds matching instances with Grokdown::Matching.arguments_from_node, and assigns aggregated types to members using Grokdown::Consuming.aggregate_node", :aggregate_failures do
     stub_const("Text", Class.new(String) do
       extend Grokdown::Matching
       extend Grokdown::Creating
-
-      def consumes?(*) = false
+      extend Grokdown::Consuming
 
       def self.matches_node?(node) = node.type == :text
 
@@ -33,7 +32,12 @@ RSpec.describe Grokdown::Document do
 
       def self.arguments_from_node(node) = {href: node.url, title: node.title}
 
-      consumes Text => :text=
+      def self.aggregate_node(inst, node)
+        case node
+        when Text
+          inst.text = node
+        end
+      end
     end)
 
     doc, paragraph, *_rest = *CommonMarker.render_doc("[text](https://host.com)").walk

--- a/spec/grokdown/document_spec.rb
+++ b/spec/grokdown/document_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Grokdown::Document do
   end
 
   it "with some Classes with Grokdown::Matching.matches_node?, builds matching instances with Grokdown::Matching.arguments_from_node, and reshapes the tree a bit with Growkdown::Consuming.consumes", :aggregate_failures do
-    text = Class.new(String) do
+    stub_const("Text", Class.new(String) do
       extend Grokdown::Matching
       extend Grokdown::Creating
 
@@ -22,9 +22,9 @@ RSpec.describe Grokdown::Document do
       def self.matches_node?(node) = node.type == :text
 
       def self.arguments_from_node(node) = node.string_content
-    end
+    end)
 
-    link = Struct.new(:href, :title, :text, keyword_init: true) do
+    stub_const("Link", Struct.new(:href, :title, :text, keyword_init: true) do
       extend Grokdown::Matching
       extend Grokdown::Creating
       extend Grokdown::Consuming
@@ -33,12 +33,12 @@ RSpec.describe Grokdown::Document do
 
       def self.arguments_from_node(node) = {href: node.url, title: node.title}
 
-      consumes text => :text=
-    end
+      consumes Text => :text=
+    end)
 
     doc, paragraph, *_rest = *CommonMarker.render_doc("[text](https://host.com)").walk
 
-    expect(described_class.new("[text](https://host.com)").each.to_a).to eq([Grokdown::NeverConsumes.new(doc), Grokdown::NeverConsumes.new(paragraph), link.new(href: "https://host.com", title: "", text: "text")])
-    expect(described_class.new("[text](https://host.com)").walk.to_a).to eq([Grokdown::NeverConsumes.new(doc), Grokdown::NeverConsumes.new(paragraph), link.new(href: "https://host.com", title: "", text: "text"), "text"])
+    expect(described_class.new("[text](https://host.com)").each.to_a).to eq([Grokdown::NeverConsumes.new(doc), Grokdown::NeverConsumes.new(paragraph), Link.new(href: "https://host.com", title: "", text: "text")])
+    expect(described_class.new("[text](https://host.com)").walk.to_a).to eq([Grokdown::NeverConsumes.new(doc), Grokdown::NeverConsumes.new(paragraph), Link.new(href: "https://host.com", title: "", text: "text"), "text"])
   end
 end


### PR DESCRIPTION
I'm not totally satisfied with the refactor, but at least it does away with the last idiosyncratic DSL method.