### PR TITLE
🚚 NeverComposable renamed to NeverComposes

### DIFF
--- a/lib/grokdown/document.rb
+++ b/lib/grokdown/document.rb
@@ -1,7 +1,7 @@
 require "commonmarker"
 require "grokdown"
 require "grokdown/matching"
-require "grokdown/never_composable"
+require "grokdown/never_composes"
 
 module Grokdown
   class Document
@@ -14,7 +14,7 @@ module Grokdown
         when Matching
           Matching.for(node).build(node)
         else
-          NeverComposable.new(node)
+          NeverComposes.new(node)
         end
 
         doc.push decorated_node

--- a/lib/grokdown/never_composes.rb
+++ b/lib/grokdown/never_composes.rb
@@ -1,7 +1,7 @@
 require "delegate"
 
 module Grokdown
-  class NeverComposable < SimpleDelegator
+  class NeverComposes < SimpleDelegator
     def can_compose?(*) = false
 
     def ==(other)

--- a/spec/grokdown/document_spec.rb
+++ b/spec/grokdown/document_spec.rb
@@ -4,12 +4,12 @@ require "grokdown/creating"
 require "grokdown/composing"
 
 RSpec.describe Grokdown::Document do
-  it "#initialized with a markdown file, creates an iterable, walk-able list of Grokdown::NeverComposable from the children of the document" do
+  it "#initialized with a markdown file, creates an iterable, walk-able list of Grokdown::NeverComposes from the children of the document" do
     doc, paragraph, link, text = *CommonMarker.render_doc("[text](https://host.com)").walk
 
-    expect(described_class.new("[text](https://host.com)").each.to_a).to eq([Grokdown::NeverComposable.new(doc), Grokdown::NeverComposable.new(paragraph), Grokdown::NeverComposable.new(link), Grokdown::NeverComposable.new(text)])
+    expect(described_class.new("[text](https://host.com)").each.to_a).to eq([Grokdown::NeverComposes.new(doc), Grokdown::NeverComposes.new(paragraph), Grokdown::NeverComposes.new(link), Grokdown::NeverComposes.new(text)])
 
-    expect(described_class.new("[text](https://host.com)").walk.to_a).to eq([Grokdown::NeverComposable.new(doc), Grokdown::NeverComposable.new(paragraph), Grokdown::NeverComposable.new(link), Grokdown::NeverComposable.new(text)])
+    expect(described_class.new("[text](https://host.com)").walk.to_a).to eq([Grokdown::NeverComposes.new(doc), Grokdown::NeverComposes.new(paragraph), Grokdown::NeverComposes.new(link), Grokdown::NeverComposes.new(text)])
   end
 
   it "with some Classes with Grokdown::Matching.matches_node?, builds matching instances with Grokdown::Matching.arguments_from_node, and composes aggregated root entities Grokdown::Composing conventional composition methods", :aggregate_failures do
@@ -37,7 +37,7 @@ RSpec.describe Grokdown::Document do
 
     doc, paragraph, *_rest = *CommonMarker.render_doc("[text](https://host.com)").walk
 
-    expect(described_class.new("[text](https://host.com)").each.to_a).to eq([Grokdown::NeverComposable.new(doc), Grokdown::NeverComposable.new(paragraph), Link.new(href: "https://host.com", title: "", text: "text")])
-    expect(described_class.new("[text](https://host.com)").walk.to_a).to eq([Grokdown::NeverComposable.new(doc), Grokdown::NeverComposable.new(paragraph), Link.new(href: "https://host.com", title: "", text: "text"), "text"])
+    expect(described_class.new("[text](https://host.com)").each.to_a).to eq([Grokdown::NeverComposes.new(doc), Grokdown::NeverComposes.new(paragraph), Link.new(href: "https://host.com", title: "", text: "text")])
+    expect(described_class.new("[text](https://host.com)").walk.to_a).to eq([Grokdown::NeverComposes.new(doc), Grokdown::NeverComposes.new(paragraph), Link.new(href: "https://host.com", title: "", text: "text"), "text"])
   end
 end

--- a/spec/grokdown/never_composes_spec.rb
+++ b/spec/grokdown/never_composes_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 require "commonmarker"
-require "grokdown/never_composable"
+require "grokdown/never_composes"
 
-RSpec.describe Grokdown::NeverComposable do
+RSpec.describe Grokdown::NeverComposes do
   subject do
     _doc, _paragraph, text = *CommonMarker.render_doc("text").walk
 


### PR DESCRIPTION
## Why?

Instances of the class being renamed receive the message `can_compose?`, and that has a fixed `false` response.

Calling it `NeverComposable` is more appropriate for the intended behaviour of an argument to `can_compose?`, rather than a receiver of `can_compose?`.